### PR TITLE
Use mcDataDir instead of working out .minecraft

### DIFF
--- a/minecraft/com/darkcart/xdolf/util/FileManager.java
+++ b/minecraft/com/darkcart/xdolf/util/FileManager.java
@@ -33,7 +33,7 @@ public class FileManager
 	
 	public FileManager()
 	{
-		xdolfDir = new File(Wrapper.getAppDir("minecraft") + File.separator + "Xdolf");
+		xdolfDir = new File(Wrapper.getMinecraftDir() + File.separator + "Xdolf");
 		if(!xdolfDir.exists())
 		{
 			xdolfDir.mkdirs();


### PR DESCRIPTION
```
Use mcDataDir via Wrapper.getMinecraftDir() instead of manually working
out the minecraft data directory based on OS.

This has the advantage of respecting the user's choice of working
directory (if set in the launch config).
```

Simplify code and allow the end-user to control where the `Xdolf` directory will end up (via mc profile working directory)