### PR TITLE
findMod(Class) should return type Class

### DIFF
--- a/minecraft/com/darkcart/xdolf/mods/Hacks.java
+++ b/minecraft/com/darkcart/xdolf/mods/Hacks.java
@@ -133,13 +133,13 @@ public class Hacks
 		return null;
 	}
 	
-	public static Module findMod(Class<?extends Module> clazz) 
+	public static <T extends Module> T findMod(Class<T> clazz)
 	{
 		for(Module mod: hackList)
 		{
 			if(mod.getClass() == clazz)
 			{
-				return mod;
+				return clazz.cast(mod);
 			}
 		}
 		


### PR DESCRIPTION
Since `Hacks.findMod(Class)` knows the type, it may as well return that type automatically.

This way you don't need to cast to use mod specific methods.